### PR TITLE
Made Configurations files more generic & Beautify Readme Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ You will need two servers. One server is for the Ngnix Reverse proxy. The other 
 ## Server 2
 1. Take ubuntu or any other linux VPS
 2. Install Ngnix
-3. Setup Ngnix configuration: https://github.com/khaleel-git/ngnix-reverse-proxy-wordpress-setup/blob/master/nginx.conf (Skip SSL block)
-4. Point your domain to this ngnix server
-5. Install SSL via lets encrypt built-in cert-bot: https://www.nginx.com/blog/using-free-ssltls-certificates-from-lets-encrypt-with-nginx/
+3. Setup Ngnix configuration: nginx.conf (Skip SSL block)
+4. Point your domain to this Ngnix server
+5. Install SSL via Let's Encrypt built-in cert-bot: Using free SSL/TLS certificates from Let's Encrypt with Nginx
 
 ## Issues
 ### 1. Ngnix Reverse Proxy Wordpress Too many redirect solution:

--- a/nginx.conf
+++ b/nginx.conf
@@ -34,10 +34,10 @@ http {
 
     server {
         listen 80;
-        server_name khaleel.work;
+        server_name example.com;
 
         location / {
-            proxy_pass http://147.182.221.201;
+            proxy_pass http://wordpress-ip-address;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -45,17 +45,17 @@ http {
     }
 
     server {
-        server_name khaleel.work;
+        server_name wordpress-server;
         location / {
-            proxy_pass http://147.182.221.201;
+            proxy_pass http://wordpress-ip-address;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
         listen 443 ssl; # managed by Certbot
-        ssl_certificate /etc/letsencrypt/live/khaleel.work/fullchain.pem; # managed by Certbot
-        ssl_certificate_key /etc/letsencrypt/live/khaleel.work/privkey.pem; # managed by Certbot
+        ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem; # managed by Certbot
+        ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem; # managed by Certbot
         include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
         ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
     }

--- a/wp-config.php
+++ b/wp-config.php
@@ -92,16 +92,17 @@ define( 'WP_DEBUG', false );
         define( 'ABSPATH', __DIR__ . '/' );
 /*}*/
 
-//define( 'WP_HOME', 'https://khaleel.work' ); define( 'WP_SITEURL', 'https://khaleel.work' );
+//define( 'WP_HOME', 'https://example.com' ); define( 'WP_SITEURL', 'https://example.com' );
 
-//define( 'WP_HOME', 'http://147.182.221.201' ); define( 'WP_SITEURL', 'http://147.182.221.201' );
 
 //define('FORCE_SSL_ADMIN', true);
 //if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
   //  $_SERVER['HTTPS'] = 'on';
 //}
 
-$_SERVER['HTTPS'] = 'On';
+// case 2 is working for me
+$_SERVER['HTTPS'] = 'On'; 
+
 
 /** Sets up WordPress vars and included files. */
 require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
In this pull request, I have made the configuration files more generic and improved the readability of the README instructions. The changes include:

**Updated the nginx.conf file** to make it more generic and adaptable to different setups.
Refactored the README instructions to provide clearer and more concise steps for setting up the server.
Changes Made:

[nginx.conf](https://github.com/khaleel-git/ngnix-reverse-proxy-wordpress-setup/blob/master/nginx.conf): Updated the Ngnix configuration file to improve its flexibility and adaptability.
Readme Instructions:

1. Take an Ubuntu or any other Linux VPS.
2. Install Ngnix.
3. Set up the Ngnix configuration by following the instructions in the [nginx.conf](https://github.com/khaleel-git/ngnix-reverse-4. proxy-WordPress-setup/blob/master/nginx.conf) file. (Skip the SSL block.)
5. Point your domain to the Ngnix server.

Install SSL using Let's Encrypt's built-in cert-bot by following the instructions in the [Using free SSL/TLS certificates from Let's Encrypt with Nginx](https://www.nginx.com/blog/using-free-ssltls-certificates-from-lets-encrypt-with-nginx/) blog post.
These changes aim to enhance the usability and clarity of the project, making it easier for users to set up the server and configure it according to their requirements.
